### PR TITLE
Allow asterisk 12 version

### DIFF
--- a/ami.js
+++ b/ami.js
@@ -38,7 +38,7 @@ function AMI(params) {
     function on_first_line(line) {
         var version,
             loginmsg;
-        version = line.match(/Asterisk Call Manager\/(1\.[0123])/);
+        version = line.match(/Asterisk Call Manager\/([12]\.[0123])/);
         if (version) {
             self.version = version[1];
             debug('successfully connected to AMI');


### PR DESCRIPTION
I just tested this with Asterisk 12, and it seems to work, although my use case was just `Originate` so that is all I tested.

But if you want to allow that version, I made a quick change to the version regex.
