### PR TITLE
Fix typescript interface recursion

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,8 @@ declare module 'yana' {
     password?: string;
   }
 
-  interface ActionResult {
-    [key: string]: string | string[];
-    eventlist?: string | ActionResult[];
+  type ActionResult = Record<string, string | string[]> & {
+      eventlist?: ActionResult[]
   }
 
   type ConnectCallback = (err: Error | undefined | null) => void;


### PR DESCRIPTION
The interface recursion probably worked in older versions of typescript but is broken in 4.9 (not sure when it broke, just trying to use it now).
I am committing fixed types that work with TypeScript 4.9.

This fixes issue #14 